### PR TITLE
Refactor parsers to be executed parser-by-parser.

### DIFF
--- a/src/module/actor/interfaces.ts
+++ b/src/module/actor/interfaces.ts
@@ -149,6 +149,27 @@ export interface ImportActor {
   items: ImportItems;
 }
 
+export interface ImportActorParser {
+  parseName: (lines: string[]) => Name;
+  parseSize: (lines: string[]) => Size;
+  parseType: (lines: string[]) => ActorType;
+  parseAlignment: (lines: string[]) => Alignment;
+  parseSenses: (lines: string[]) => Senses;
+  parseLanguages: (lines: string[]) => Languages;
+  parseBiography: (lines: string[]) => Biography;
+  parseDamageImmunities: (lines: string[]) => DamageTypes;
+  parseDamageResistances: (lines: string[]) => DamageTypes;
+  parseConditionImmunities: (lines: string[]) => ConditionTypes;
+  parseDamageVulnerabilities: (lines: string[]) => DamageTypes;
+  parseHealth: (lines: string[]) => Health;
+  parseRating: (lines: string[]) => Rating;
+  parseArmorClass: (lines: string[]) => ArmorClass;
+  parseAbilities: (lines: string[]) => Abilities;
+  parseSpeed: (lines: string[]) => Speed;
+  parseSkills: (lines: string[]) => Skill[];
+  parseItems: (lines: string[], abilities: Abilities) => ImportItems;
+}
+
 export interface Formula {
   value: number;
   str?: string;

--- a/src/module/actor/interfaces.ts
+++ b/src/module/actor/interfaces.ts
@@ -150,24 +150,24 @@ export interface ImportActor {
 }
 
 export interface ImportActorParser {
-  parseName: (lines: string[]) => Name;
-  parseSize: (lines: string[]) => Size;
-  parseType: (lines: string[]) => ActorType;
-  parseAlignment: (lines: string[]) => Alignment;
-  parseSenses: (lines: string[]) => Senses;
-  parseLanguages: (lines: string[]) => Languages;
-  parseBiography: (lines: string[]) => Biography;
-  parseDamageImmunities: (lines: string[]) => DamageTypes;
-  parseDamageResistances: (lines: string[]) => DamageTypes;
-  parseConditionImmunities: (lines: string[]) => ConditionTypes;
-  parseDamageVulnerabilities: (lines: string[]) => DamageTypes;
-  parseHealth: (lines: string[]) => Health;
-  parseRating: (lines: string[]) => Rating;
-  parseArmorClass: (lines: string[]) => ArmorClass;
-  parseAbilities: (lines: string[]) => Abilities;
-  parseSpeed: (lines: string[]) => Speed;
-  parseSkills: (lines: string[]) => Skill[];
-  parseItems: (lines: string[], abilities: Abilities) => ImportItems;
+  parseName: ((lines: string[]) => Name)[];
+  parseSize: ((lines: string[]) => Size)[];
+  parseType: ((lines: string[]) => ActorType)[];
+  parseAlignment: ((lines: string[]) => Alignment)[];
+  parseSenses: ((lines: string[]) => Senses)[];
+  parseLanguages: ((lines: string[]) => Languages)[];
+  parseBiography: ((lines: string[]) => Biography)[];
+  parseDamageImmunities: ((lines: string[]) => DamageTypes)[];
+  parseDamageResistances: ((lines: string[]) => DamageTypes)[];
+  parseConditionImmunities: ((lines: string[]) => ConditionTypes)[];
+  parseDamageVulnerabilities: ((lines: string[]) => DamageTypes)[];
+  parseHealth: ((lines: string[]) => Health)[];
+  parseRating: ((lines: string[]) => Rating)[];
+  parseArmorClass: ((lines: string[]) => ArmorClass)[];
+  parseAbilities: ((lines: string[]) => Abilities)[];
+  parseSpeed: ((lines: string[]) => Speed)[];
+  parseSkills: ((lines: string[]) => Skill[])[];
+  parseItems: ((lines: string[], abilities: Abilities) => ImportItems)[];
 }
 
 export interface Formula {

--- a/src/module/actor/parsers/available.ts
+++ b/src/module/actor/parsers/available.ts
@@ -1,41 +1,4 @@
-import {
-  parseNameWTC,
-  parseACWTC,
-  parseAlignmentWTC,
-  parseBiographyWTC,
-  parseConditionImmunitiesWTC,
-  parseDamageImmunitiesWTC,
-  parseDamageResistancesWTC,
-  parseDamageVulnerabilitiesWTC,
-  parseHealthWTC,
-  parseLanguagesWTC,
-  parseMultilineAbilitiesWTC,
-  parseRatingWTC,
-  parseSensesWTC,
-  parseSizeWTC,
-  parseSkillsWTC,
-  parseSpeedWTC,
-  parseAbilitiesWTC,
-  parseTypeWTC,
-  parseVerticalKeyValueAbilitiesWTC,
-  parseItemsWTC,
-} from './wtcTextBlock';
+import { parseActorWTC } from './wtcTextBlock';
+import { parseActorHB } from './homebreweryTextBlock';
 
-export const nameParsers = [parseNameWTC];
-export const ratingParsers = [parseRatingWTC];
-export const typeParsers = [parseTypeWTC];
-export const alignmentParsers = [parseAlignmentWTC];
-export const biographyParsers = [parseBiographyWTC];
-export const languagesParsers = [parseLanguagesWTC];
-export const sizeParsers = [parseSizeWTC];
-export const healthParsers = [parseHealthWTC];
-export const sensesParsers = [parseSensesWTC];
-export const acParsers = [parseACWTC];
-export const damageImmunitiesParsers = [parseDamageImmunitiesWTC];
-export const damageResistancesParsers = [parseDamageResistancesWTC];
-export const conditionImmunitiesParsers = [parseConditionImmunitiesWTC];
-export const damageVulnerabilitiesParsers = [parseDamageVulnerabilitiesWTC];
-export const abilitiesParsers = [parseAbilitiesWTC, parseMultilineAbilitiesWTC, parseVerticalKeyValueAbilitiesWTC];
-export const speedParsers = [parseSpeedWTC];
-export const skillsParsers = [parseSkillsWTC];
-export const itemsParsers = [parseItemsWTC];
+export const actorParsers = [parseActorWTC(), parseActorHB()];

--- a/src/module/actor/parsers/available.ts
+++ b/src/module/actor/parsers/available.ts
@@ -1,4 +1,3 @@
 import { parseActorWTC } from './wtcTextBlock';
-import { parseActorHB } from './homebreweryTextBlock';
 
-export const actorParsers = [parseActorWTC(), parseActorHB()];
+export const actorParsers = [parseActorWTC()];

--- a/src/module/actor/parsers/index.ts
+++ b/src/module/actor/parsers/index.ts
@@ -1,67 +1,9 @@
 import { ImportActor } from '../interfaces';
-import {
-  nameParsers,
-  ratingParsers,
-  typeParsers,
-  alignmentParsers,
-  biographyParsers,
-  languagesParsers,
-  sizeParsers,
-  healthParsers,
-  sensesParsers,
-  acParsers,
-  damageImmunitiesParsers,
-  damageResistancesParsers,
-  conditionImmunitiesParsers,
-  damageVulnerabilitiesParsers,
-  abilitiesParsers,
-  speedParsers,
-  skillsParsers,
-  itemsParsers,
-} from './available';
+import { actorParsers } from './available';
 
-import {
-  tryAlignmentParse,
-  tryBiographyParse,
-  tryHealthParse,
-  tryLanguageParse,
-  tryNameParse,
-  tryParseArmorClass,
-  tryParseConditionImmunities,
-  tryParseDamageImmunities,
-  tryParseDamageResistances,
-  tryParseDamageVulnerabilities,
-  tryParseSkills,
-  tryParseSpeed,
-  tryParseAbilities,
-  tryRatingParse,
-  trySensesParse,
-  trySizeParse,
-  tryTypeParse,
-  tryParseItems,
-} from './typeGuardParserRunners';
+import { tryActorParse } from './typeGuardParserRunners';
 
 export function textToActor(input: string): ImportActor {
   const lines = input.split('\n');
-  const abilities = tryParseAbilities(abilitiesParsers, lines);
-  return {
-    name: tryNameParse(nameParsers, lines),
-    rating: tryRatingParse(ratingParsers, lines),
-    type: tryTypeParse(typeParsers, lines),
-    alignment: tryAlignmentParse(alignmentParsers, lines),
-    biography: tryBiographyParse(biographyParsers, lines),
-    languages: tryLanguageParse(languagesParsers, lines),
-    size: trySizeParse(sizeParsers, lines),
-    health: tryHealthParse(healthParsers, lines),
-    senses: trySensesParse(sensesParsers, lines),
-    armorClass: tryParseArmorClass(acParsers, lines),
-    damageImmunities: tryParseDamageImmunities(damageImmunitiesParsers, lines),
-    damageResistances: tryParseDamageResistances(damageResistancesParsers, lines),
-    conditionImmunities: tryParseConditionImmunities(conditionImmunitiesParsers, lines),
-    damageVulnerabilities: tryParseDamageVulnerabilities(damageVulnerabilitiesParsers, lines),
-    abilities,
-    speed: tryParseSpeed(speedParsers, lines),
-    skills: tryParseSkills(skillsParsers, lines),
-    items: tryParseItems(itemsParsers, lines, abilities),
-  };
+  return tryActorParse(actorParsers, lines);
 }

--- a/src/module/actor/parsers/typeGuardParserRunners.ts
+++ b/src/module/actor/parsers/typeGuardParserRunners.ts
@@ -47,11 +47,15 @@ export function trySingleActorParse(parser: ImportActorParser, lines: string[]):
   };
 }
 
+export type ParserOutput = ActorTypes;
+export type ActorParser = (input: string[]) => ParserOutput;
+
 export function tryActorParse(parsers: ImportActorParser[], lines: string[]): ImportActor {
   const parserErrors = [];
   for (const parser of parsers) {
     try {
-      return trySingleActorParse(parser, lines);
+      const result = trySingleActorParse(parser, lines);
+      return result;
     } catch (error) {
       parserErrors.push(error);
     }
@@ -59,19 +63,29 @@ export function tryActorParse(parsers: ImportActorParser[], lines: string[]): Im
   throw new Error(`Could not parse element: ${JSON.stringify(parserErrors.join('\n'), null, 2)}`);
 }
 
-export type ParserOutput = ActorTypes;
-export type ActorParser = (input: string[]) => ParserOutput;
+export function tryParsers(parsers: ActorParser[], input: string[]): ParserOutput {
+  const parserErrors = [];
+  for (const parser of parsers) {
+    try {
+      const result = parser(input);
+      return result;
+    } catch (error) {
+      parserErrors.push(error);
+    }
+  }
+  throw new Error(`Could not parse element: ${JSON.stringify(parserErrors.join('\n'), null, 2)}`);
+}
 
-export function tryNameParse(parser: ActorParser, lines: string[]): Name {
-  const name = parser(lines);
+export function tryNameParse(parsers: ActorParser[], lines: string[]): Name {
+  const name = tryParsers(parsers, lines);
   if (typeof name !== 'string') {
     throw new Error(`Could not parse name: ${name}`);
   }
   return name;
 }
 
-export function tryRatingParse(parser: ActorParser, lines: string[]): Rating {
-  const rating = parser(lines);
+export function tryRatingParse(parsers: ActorParser[], lines: string[]): Rating {
+  const rating = tryParsers(parsers, lines);
   if (!(rating as Rating).xp) {
     return {
       xp: 0,
@@ -80,25 +94,25 @@ export function tryRatingParse(parser: ActorParser, lines: string[]): Rating {
   return rating as Rating;
 }
 
-export function tryTypeParse(parser: ActorParser, lines: string[]): ActorType {
-  const type = parser(lines);
+export function tryTypeParse(parsers: ActorParser[], lines: string[]): ActorType {
+  const type = tryParsers(parsers, lines);
   if (typeof type !== 'string') {
     throw new Error(`Could not parse type: ${type}`);
   }
   return type;
 }
 
-export function tryAlignmentParse(parser: ActorParser, lines: string[]): Alignment {
-  const alignment = parser(lines);
+export function tryAlignmentParse(parsers: ActorParser[], lines: string[]): Alignment {
+  const alignment = tryParsers(parsers, lines);
   if (typeof alignment !== 'string') {
     throw new Error(`Could not parse alignment: ${alignment}`);
   }
   return alignment;
 }
 
-export function tryBiographyParse(parser: ActorParser, lines: string[]): Biography {
+export function tryBiographyParse(parsers: ActorParser[], lines: string[]): Biography {
   try {
-    const biography = parser(lines);
+    const biography = tryParsers(parsers, lines);
     if (typeof biography !== 'string') {
       // Biography is optional
       return '';
@@ -110,49 +124,49 @@ export function tryBiographyParse(parser: ActorParser, lines: string[]): Biograp
   }
 }
 
-export function tryLanguageParse(parser: ActorParser, lines: string[]): Languages {
-  const languages = parser(lines);
+export function tryLanguageParse(parsers: ActorParser[], lines: string[]): Languages {
+  const languages = tryParsers(parsers, lines);
   if (!Array.isArray(languages)) {
     throw new Error(`Could not parse languages: ${languages}`);
   }
   return languages as Languages;
 }
 
-export function trySizeParse(parser: ActorParser, lines: string[]): Size {
-  const size = parser(lines);
+export function trySizeParse(parsers: ActorParser[], lines: string[]): Size {
+  const size = tryParsers(parsers, lines);
   if (typeof size !== 'string') {
     throw new Error(`Could not parse size: ${size}`);
   }
   return size as Size;
 }
 
-export function tryHealthParse(parser: ActorParser, lines: string[]): Health {
-  const health = parser(lines);
+export function tryHealthParse(parsers: ActorParser[], lines: string[]): Health {
+  const health = tryParsers(parsers, lines);
   if (!(health as Health).value) {
     throw new Error(`Could not parse health: ${health}`);
   }
   return health as Health;
 }
 
-export function trySensesParse(parser: ActorParser, lines: string[]): Senses {
-  const senses = parser(lines);
+export function trySensesParse(parsers: ActorParser[], lines: string[]): Senses {
+  const senses = tryParsers(parsers, lines);
   if (!(senses as Senses).units) {
     throw new Error(`Could not parse senses: ${senses}`);
   }
   return senses as Senses;
 }
 
-export function tryParseArmorClass(parser: ActorParser, lines: string[]): ArmorClass {
-  const armorClass = parser(lines);
+export function tryParseArmorClass(parsers: ActorParser[], lines: string[]): ArmorClass {
+  const armorClass = tryParsers(parsers, lines);
   if (!(armorClass as ArmorClass).value) {
     throw new Error(`Could not parse armor class: ${armorClass}`);
   }
   return armorClass as ArmorClass;
 }
 
-export function tryParseDamageImmunities(parser: ActorParser, lines: string[]): DamageType[] {
+export function tryParseDamageImmunities(parsers: ActorParser[], lines: string[]): DamageType[] {
   try {
-    const damageImmunities = parser(lines);
+    const damageImmunities = tryParsers(parsers, lines);
     if (!Array.isArray(damageImmunities)) {
       return [];
     }
@@ -162,9 +176,9 @@ export function tryParseDamageImmunities(parser: ActorParser, lines: string[]): 
   }
 }
 
-export function tryParseDamageResistances(parser: ActorParser, lines: string[]): DamageType[] {
+export function tryParseDamageResistances(parsers: ActorParser[], lines: string[]): DamageType[] {
   try {
-    const damageResistances = parser(lines);
+    const damageResistances = tryParsers(parsers, lines);
     if (!Array.isArray(damageResistances)) {
       // Damage resistances are optional
       return [];
@@ -176,9 +190,9 @@ export function tryParseDamageResistances(parser: ActorParser, lines: string[]):
   }
 }
 
-export function tryParseConditionImmunities(parser: ActorParser, lines: string[]): ConditionTypes {
+export function tryParseConditionImmunities(parsers: ActorParser[], lines: string[]): ConditionTypes {
   try {
-    const conditionImmunities = parser(lines);
+    const conditionImmunities = tryParsers(parsers, lines);
     if (!Array.isArray(conditionImmunities)) {
       // Condition immunities are optional
       return [];
@@ -190,9 +204,9 @@ export function tryParseConditionImmunities(parser: ActorParser, lines: string[]
   }
 }
 
-export function tryParseDamageVulnerabilities(parser: ActorParser, lines: string[]): DamageType[] {
+export function tryParseDamageVulnerabilities(parsers: ActorParser[], lines: string[]): DamageType[] {
   try {
-    const damageVulnerabilities = parser(lines);
+    const damageVulnerabilities = tryParsers(parsers, lines);
     if (!Array.isArray(damageVulnerabilities)) {
       // Damage vulnerabilities are optional
       return [];
@@ -204,8 +218,8 @@ export function tryParseDamageVulnerabilities(parser: ActorParser, lines: string
   }
 }
 
-export function tryParseAbilities(parser: ActorParser, lines: string[]): Abilities {
-  const stats = parser(lines);
+export function tryParseAbilities(parsers: ActorParser[], lines: string[]): Abilities {
+  const stats = tryParsers(parsers, lines);
   if (!(stats as Abilities).str) {
     throw new Error(`Could not parse stats: ${stats}`);
   }
@@ -213,17 +227,17 @@ export function tryParseAbilities(parser: ActorParser, lines: string[]): Abiliti
   return statsWithSaves as Abilities;
 }
 
-export function tryParseSpeed(parser: ActorParser, lines: string[]): Speed {
-  const speed = parser(lines);
+export function tryParseSpeed(parsers: ActorParser[], lines: string[]): Speed {
+  const speed = tryParsers(parsers, lines);
   if (typeof speed !== 'number') {
     throw new Error(`Could not parse speed: ${speed}`);
   }
   return speed;
 }
 
-export function tryParseSkills(parser: ActorParser, lines: string[]): Skill[] {
+export function tryParseSkills(parsers: ActorParser[], lines: string[]): Skill[] {
   try {
-    const skills = parser(lines);
+    const skills = tryParsers(parsers, lines);
 
     if (!Array.isArray(skills)) {
       // Skills are optional
@@ -236,17 +250,30 @@ export function tryParseSkills(parser: ActorParser, lines: string[]): Skill[] {
   }
 }
 
-export function tryParseFeatures(parser: ActorParser, lines: string[]): Features {
-  const features = parser(lines);
+export function tryParseFeatures(parsers: ActorParser[], lines: string[]): Features {
+  const features = tryParsers(parsers, lines);
   if (!Array.isArray(features)) {
     throw new Error(`Could not parse features: ${features}`);
   }
   return features as Feature[];
 }
 
+export function tryItemParsers(parsers: ItemParser[], input: string[], abilities: Abilities): ParserOutput {
+  const parserErrors = [];
+  for (const parser of parsers) {
+    try {
+      const result = parser(input, abilities);
+      return result;
+    } catch (error) {
+      parserErrors.push(error);
+    }
+  }
+  throw new Error(`Could not parse element: ${JSON.stringify(parserErrors.join('\n'), null, 2)}`);
+}
+
 export type ItemParser = (input: string[], abilities: Abilities) => ParserOutput;
-export function tryParseItems(parser: ItemParser, lines: string[], abilities: Abilities): ImportItems {
-  const items = parser(lines, abilities);
+export function tryParseItems(parsers: ItemParser[], lines: string[], abilities: Abilities): ImportItems {
+  const items = tryItemParsers(parsers, lines, abilities);
   if (!Array.isArray(items)) {
     throw new Error(`Could not parse items: ${items}`);
   }

--- a/src/module/actor/parsers/wtcTextBlock.ts
+++ b/src/module/actor/parsers/wtcTextBlock.ts
@@ -29,24 +29,24 @@ const FEATURE_HEADERS = ['Actions', 'Reactions'];
 
 export function parseActorWTC(): ImportActorParser {
   return {
-    parseName: parseNameWTC,
-    parseRating: parseRatingWTC,
-    parseType: parseTypeWTC,
-    parseAlignment: parseAlignmentWTC,
-    parseBiography: parseBiographyWTC,
-    parseLanguages: parseLanguagesWTC,
-    parseSize: parseSizeWTC,
-    parseHealth: parseHealthWTC,
-    parseSenses: parseSensesWTC,
-    parseArmorClass: parseACWTC,
-    parseDamageImmunities: parseDamageImmunitiesWTC,
-    parseDamageResistances: parseDamageResistancesWTC,
-    parseConditionImmunities: parseConditionImmunitiesWTC,
-    parseDamageVulnerabilities: parseDamageVulnerabilitiesWTC,
-    parseAbilities: tryStatParsers,
-    parseSpeed: parseSpeedWTC,
-    parseSkills: parseSkillsWTC,
-    parseItems: parseItemsWTC,
+    parseName: [parseNameWTC],
+    parseRating: [parseRatingWTC],
+    parseType: [parseTypeWTC],
+    parseAlignment: [parseAlignmentWTC],
+    parseBiography: [parseBiographyWTC],
+    parseLanguages: [parseLanguagesWTC],
+    parseSize: [parseSizeWTC],
+    parseHealth: [parseHealthWTC],
+    parseSenses: [parseSensesWTC],
+    parseArmorClass: [parseACWTC],
+    parseDamageImmunities: [parseDamageImmunitiesWTC],
+    parseDamageResistances: [parseDamageResistancesWTC],
+    parseConditionImmunities: [parseConditionImmunitiesWTC],
+    parseDamageVulnerabilities: [parseDamageVulnerabilitiesWTC],
+    parseAbilities: [parseAbilitiesWTC, parseMultilineAbilitiesWTC, parseVerticalKeyValueAbilitiesWTC],
+    parseSpeed: [parseSpeedWTC],
+    parseSkills: [parseSkillsWTC],
+    parseItems: [parseItemsWTC],
   };
 }
 
@@ -152,7 +152,7 @@ function zipStats(abilityKeys: string[], abilities: number[], modifiers: string[
   ) as Abilities;
 }
 
-export function parseAbilitiesWTC(inputList: string[]) {
+export function parseAbilitiesWTC(inputList: string[]): Abilities {
   const abilityLine = inputList.find(isAbilityLine);
   if (!abilityLine) {
     throw new Error('Could not find ability line');

--- a/src/module/actor/parsers/wtcTextBlock.ts
+++ b/src/module/actor/parsers/wtcTextBlock.ts
@@ -13,6 +13,8 @@ import {
   Features,
   Group,
   Health,
+  ImportActor,
+  ImportActorParser,
   ImportItems,
   Languages,
   Name,
@@ -24,6 +26,29 @@ import {
 import { parseGenericFormula } from './generic';
 
 const FEATURE_HEADERS = ['Actions', 'Reactions'];
+
+export function parseActorWTC(): ImportActorParser {
+  return {
+    parseName: parseNameWTC,
+    parseRating: parseRatingWTC,
+    parseType: parseTypeWTC,
+    parseAlignment: parseAlignmentWTC,
+    parseBiography: parseBiographyWTC,
+    parseLanguages: parseLanguagesWTC,
+    parseSize: parseSizeWTC,
+    parseHealth: parseHealthWTC,
+    parseSenses: parseSensesWTC,
+    parseArmorClass: parseACWTC,
+    parseDamageImmunities: parseDamageImmunitiesWTC,
+    parseDamageResistances: parseDamageResistancesWTC,
+    parseConditionImmunities: parseConditionImmunitiesWTC,
+    parseDamageVulnerabilities: parseDamageVulnerabilitiesWTC,
+    parseAbilities: tryStatParsers,
+    parseSpeed: parseSpeedWTC,
+    parseSkills: parseSkillsWTC,
+    parseItems: parseItemsWTC,
+  };
+}
 
 export function parseHealthWTC(lines: string[]) {
   const healthLine = lines.find((line) => line.includes('Hit Points')) || '(1d6 + 1)';

--- a/test/actor/parsers.test.ts
+++ b/test/actor/parsers.test.ts
@@ -1,0 +1,10 @@
+import { textToActor } from '../../src/module/actor/parsers/index';
+
+describe('WTC text block', () => {
+  it('should parse a WTC text block', () => {
+    const actorText =
+      'Big Bara\nMedium humanoid (warforged), neutral evil\nArmor Class 18 (natural armor, Imposing Majesty)\nHit Points 117 (18d8 + 36)\nSpeed 30 ft.\nSTR\n DEX\n CON\n INT\n WIS\n CHA\n14 (+2)\n 17 (+3)\n 15 (+2)\n 13 (+1)\n 16 (+3)\n 18 (+4)\nSaving Throws Con +6, Wis +7\nSkills Perception +7, Survival +7\nDamage Immunities poison\nCondition Immunities charmed, frightened, poisoned\nSenses darkvision 60 ft., passive Perception 17\nLanguages Common\nChallenge 9 (5,000 XP)\nImposing Majesty. Big Bara adds her Charisma bonus to her AC\n(included above).\nWarforged Resilience. Big Bara is immune to disease and magic\ncan’t put her to sleep.\nActions\nMultiattack. Big Bara makes two attacks, either with her\nshortsword or armbow.\nShortsword. Melee Weapon Attack: +7 to hit, reach 5 ft., one\ntarget. Hit: 6 (1d6 + 3) piercing damage plus 13 (3d8) poi-\nson damage.\nArmbow. Ranged Weapon Attack: +7 to hit, range 30/120 ft.,\none target. Hit: 10 (2d6 +3) piercing damage plus 13 (3d8) poi-\nson damage.\nPoisonous Cloud (2/Day). Poison gas fills a 20-foot-radius\nsphere centered on a point Big Bara can see within 50 feet of\nher. The gas spreads around corners and remains until the start\nof Big Bara’s next turn. Each creature that starts its turn in the\ngas must succeed on a DC 16 Constitution saving throw or be\npoisoned for 1 minute. A creature can repeat the saving throw\nat the end of each of its turns, ending the effect on itself on\na success.';
+    const actor = textToActor(actorText);
+    expect(actor.biography).toBe('Medium humanoid (warforged), neutral evil');
+  });
+});


### PR DESCRIPTION
Previously, parser functions were executed piecewise, meaning that any parser could contribute to any part of the resulting actor. This refactors the parser interface to execute each parser completely or not at all.

I'm not very familiar with Typescript, so let me know if there is a more idiomatic way to do this, happy to make changes.