### PR TITLE
fix(actor): classify feats correctly

### DIFF
--- a/src/module/actor/parsers/typeGuardParserRunners.ts
+++ b/src/module/actor/parsers/typeGuardParserRunners.ts
@@ -70,7 +70,7 @@ export function tryParsers(parsers: ActorParser[], input: string[]): ParserOutpu
       const result = parser(input);
       return result;
     } catch (error) {
-      parserErrors.push(error);
+      parserErrors.push(`Parser error for [${parser.name}] -> ${error}`);
     }
   }
   throw new Error(`Could not parse element: ${JSON.stringify(parserErrors.join('\n'), null, 2)}`);

--- a/src/module/item/parsers/textBlock.ts
+++ b/src/module/item/parsers/textBlock.ts
@@ -78,14 +78,12 @@ export function parseDamageType(from: string): string {
 }
 
 export function parseType(description: string): ItemType {
-  if (/weapon/i.test(description)) return 'weapon';
+  // match if (1d8)
+  if (isWeaponType(description)) return 'weapon';
   if (/armor/i.test(description)) return 'equipment';
   if (/unil the next dawn/i.test(description)) return 'consumable';
   if (/beginning at/i.test(description)) return 'feat';
   if (/starting at/i.test(description)) return 'feat';
-  if (/melee weapon attack/i.test(description)) return 'weapon';
-  if (/ranged weapon attack/i.test(description)) return 'weapon';
-  if (/melee or ranged weapon attack/i.test(description)) return 'weapon';
   return 'consumable';
 }
 
@@ -132,13 +130,18 @@ export function buildDamageParts(description: string): string[][] {
   return parts;
 }
 
+// regex to match a die formula
+
+export function isWeaponType(input: string): boolean {
+  const dieRegex = /(\d+d\d+)/;
+  return dieRegex.test(input) && /weapon/i.test(input);
+}
+
 // the logic for parsing type is different if it is sourced from a monster
 export function parseTypeFromActorFeature(input: string): ItemType {
   if (/beginning at/i.test(input)) return 'feat';
   if (/starting at/i.test(input)) return 'feat';
-  if (/melee weapon attack/i.test(input)) return 'weapon';
-  if (/ranged weapon attack/i.test(input)) return 'weapon';
-  if (/melee or ranged weapon attack/i.test(input)) return 'weapon';
+  if (isWeaponType(input)) return 'weapon';
   return 'feat';
 }
 
@@ -183,7 +186,7 @@ export function actionTypeExtraData(actionType: string | undefined, { descriptio
 export function parseWeapon(name: string, description: string, inputAbility?: ShortAbility): WeaponType {
   const ability = inputAbility || 'str';
   const itemType: FifthItemType = parseTypeFromActorFeature(description);
-  if (itemType !== 'weapon') throw new Error(`${name} is not a weapon`);
+  if (itemType !== 'weapon') throw new Error(`${name} is not a weapon, it is a ${itemType}`);
   const damage: Damage = { parts: buildDamageParts(description) };
   const actionType = parseActionType(description);
   if (actionType !== 'rwak' && actionType !== 'mwak') throw new Error(`${name} is not a weapon`);
@@ -298,7 +301,7 @@ export function parseSpell(name: string, description: string, inputAbility?: Sho
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function parseFeat(name: string, description: string, _?: ShortAbility): FeatType {
   const itemType: FifthItemType = parseTypeFromActorFeature(description);
-  if (itemType !== 'feat') throw new Error(`${name} is not a feat`);
+  if (itemType !== 'feat') throw new Error(`${name} is not a feat, it is an ${itemType}`);
   return {
     name,
     type: 'feat',

--- a/test/item/parsers/textBlock.test.ts
+++ b/test/item/parsers/textBlock.test.ts
@@ -1,4 +1,4 @@
-import { parseSpell, parseWeapon } from '../../../src/module/item/parsers/textBlock';
+import { parseSpell, parseTypeFromActorFeature, parseWeapon } from '../../../src/module/item/parsers/textBlock';
 import { parseItem } from '../../../src/module/item/parsers/available';
 describe('parseWeapon', () => {
   it('should parse a shortsword', () => {
@@ -100,5 +100,13 @@ describe('tryParsers', () => {
       name: 'Magic Weapons',
       type: 'feat',
     });
+  });
+});
+
+describe('parseTypeFromActorFeature', () => {
+  it('should parse text without a die formula as a feat', () => {
+    const itemText =
+      "When the bugbear hits with a melee weapon attack, the attack deals one extra die of the weapon's damage to the target (included below).";
+    expect(parseTypeFromActorFeature(itemText)).toEqual('feat');
   });
 });


### PR DESCRIPTION
Fix #37 
- When parsing items, classify a feat as a weapon more intelligently
- increase logging for errors
- add unit test for monster type causing errors