### PR TITLE
fix(journal): add character checks for titles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "Foundry VTT Content Parser",
-      "version": "0.2.8",
+      "version": "0.2.20",
       "hasInstallScript": true,
       "devDependencies": {
         "@guanghechen/rollup-plugin-copy": "^1.8.5",

--- a/src/module/journal/index.ts
+++ b/src/module/journal/index.ts
@@ -1,1 +1,1 @@
-export { processInputJson } from './journalFromJson';
+export { processInputJSON } from './routes/journalFromJson';

--- a/src/module/journal/parsers/multipleTextBlocks.ts
+++ b/src/module/journal/parsers/multipleTextBlocks.ts
@@ -5,20 +5,24 @@ export interface MultipleTextBlocks {
   entries: TextBlock[];
 }
 
-function isSizeOfTitle(line: string) {
+function isTitle(line: string) {
   const shortEnough = line.split(' ').length < 7;
   const hasBullet = line.includes('•');
   const endsWithColon = line.endsWith(':');
   // first character and last character are parens
   const hasParens = line.trim().startsWith('(') && line.trim().endsWith(')');
-  return shortEnough && !hasBullet && line.length > 0 && !endsWithColon && !hasParens;
+  const endsWithComma = line.endsWith(',');
+  const startsWithDash = line.startsWith('-');
+  return (
+    shortEnough && !hasBullet && line.length > 0 && !endsWithColon && !hasParens && !endsWithComma && !startsWithDash
+  );
 }
 
 export const parseMultipleTextBlocks = (input: string): MultipleTextBlocks => {
   const lines = input.split('\n');
   let entries: TextBlock[] = [];
   lines.forEach((line) => {
-    if (isSizeOfTitle(line)) {
+    if (isTitle(line)) {
       const name = line.trim();
       entries.push({ name, content: '' });
     } else {


### PR DESCRIPTION
When splitting journal titles make sure they:
- don't start or end with a dash
- don't end with a comma